### PR TITLE
Remove creator limit to be owned by System Program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ node_module
 
 #adding dev keypair in gitignore
 dev.json
+
+#adding test ledger folder to gitignore
+test-ledger/*

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ Cargo.lock
 .next
 .vercel
 node_module
+
+#ignore .anchor folder
+.anchor/*
+
+#adding dev keypair in gitignore
+dev.json

--- a/programs/shadow-nft-standard/src/error.rs
+++ b/programs/shadow-nft-standard/src/error.rs
@@ -29,9 +29,6 @@ pub enum ErrorCode {
     #[msg("Attempted to create a group which exceeds the maximum number of members")]
     ExceedsMaxGroupSize,
 
-    #[msg("A creator must be a system account")]
-    CreatorMustBeSystemAccount,
-
     #[msg("A creator was not present for a multisig operation")]
     CreatorNotPresentForMultisig,
 

--- a/programs/shadow-nft-standard/src/instructions/create_group.rs
+++ b/programs/shadow-nft-standard/src/instructions/create_group.rs
@@ -15,14 +15,6 @@ use crate::{
 /// before initializing the `CreatorGroup` value. This should be done regardless
 /// of `multisig`.
 pub fn handle_create_group(ctx: Context<CreateGroup>, args: CreateGroupArgs) -> Result<()> {
-    // Check that remaining accounts are all system accounts
-    for account in ctx.remaining_accounts {
-        if *account.owner != System::id() {
-            verbose_msg!("A non-SystemAccount was passed in as a creator");
-            return Err(ErrorCode::CreatorMustBeSystemAccount.into());
-        }
-    }
-
     // Gather signing creator
     let mut creators = Vec::with_capacity(1 + ctx.remaining_accounts.len());
     creators.push(ctx.accounts.creator.key());


### PR DESCRIPTION
## Description
Removed CreatorMustBeSystemAccount error code and constraint from program code. Also made a few additions to .gitignore file. Solves issue #18 

## Testing
Ran the unit tests. There was one failing unit test even before the commit in the main branch already but that seems to be unrelated to this, it seems like a PDA seed error in some other part of the codebase, will deal with it separately in a different PR. Except for that, no new failing unit tests were observed


